### PR TITLE
Implement Earnings Withdrawal Functionality

### DIFF
--- a/contracts/Faker.sol
+++ b/contracts/Faker.sol
@@ -156,11 +156,21 @@ contract Faker {
 
   // ======================================== Voting Phase ========================================
 
-  function withdrawEarnings(uint256[] _phases) external {
+  function withdrawEarnings(uint256[] calldata _phases) external {
     // Whenever you add or withdraw maker, you withdraw earnings
-
+    for(uint256 i = 0; i < _phases.length; i++) {
+      withdrawPhaseEarnings(_phases[i]);
+    }
   }
 
+  function withdrawPhaseEarnings(uint256 _phase) internal {
+    uint256 _currentPhase = getCurrentPhase();
+    require(_phase <= _currentPhase, "Faker: Phase Is In Future");
+
+    bool isCurrentPhase = _phase == _currentPhase;
+    bool isAfterAuction = ((!isShift()) && (!isAuction()));
+    require((!isCurrentPhase) || isAfterAuction, "Faker: Earnings For Phase Not Yet Withdrawable");
+  }
 
   // =========================================== Helpers ===========================================
 

--- a/contracts/Faker.sol
+++ b/contracts/Faker.sol
@@ -74,7 +74,7 @@ contract Faker {
   uint256 public totalMaker;
 
   // Variables for managing earnings
-  mapping (address => mapping (uint256 => bool)) phaseEarningWithdrawls;
+  mapping (address => mapping (uint256 => bool)) phaseEarningWithdrawals;
 
   // Variables for managing bids
   struct Bid {
@@ -187,7 +187,7 @@ contract Faker {
     bool isAfterAuction = ((!isShift()) && (!isAuction()));
     require((!isCurrentPhase) || isAfterAuction, "Faker: Earnings For Phase Not Yet Withdrawable");
 
-    recordEarningsWithdrawl(msg.sender, _phase);
+    recordEarningsWithdrawal(msg.sender, _phase);
     uint256 _earnings = makerDeposits[msg.sender].amount.mul(bids[_phase].amount).div(bids[_phase].makerAmount);
 
     require(
@@ -215,12 +215,12 @@ contract Faker {
     return (getCurrentPeriod() % phaseLength == 1);
   }
 
-  function recordEarningsWithdrawl(address _depositor, uint256 _phase) internal {
-    phaseEarningWithdrawls[_depositor][_phase] = true;
+  function recordEarningsWithdrawal(address _depositor, uint256 _phase) internal {
+    phaseEarningWithdrawals[_depositor][_phase] = true;
   }
 
   function hasWithdrawnEarnings(address _depositor, uint256 _phase) public view returns (bool) {
-    return phaseEarningWithdrawls[_depositor][_phase];
+    return phaseEarningWithdrawals[_depositor][_phase];
   }
 
   modifier onlyShift() {

--- a/contracts/Faker.sol
+++ b/contracts/Faker.sol
@@ -72,6 +72,7 @@ contract Faker {
   struct Bid {
     address bidder;
     uint256 amount;
+    uint256 mkrAmount; // amount of maker being bid on
   }
   mapping (uint256 => Bid) public bids; // period number => Bid
 
@@ -151,6 +152,13 @@ contract Faker {
       bidToken.transferFrom(msg.sender, address(this), _bidAmount),
       "Faker: Bid transfer could not be completed"
     );
+  }
+
+  // ======================================== Voting Phase ========================================
+
+  function withdrawEarnings(uint256[] _phases) external {
+    // Whenever you add or withdraw maker, you withdraw earnings
+
   }
 
 

--- a/test/faker-auction.js
+++ b/test/faker-auction.js
@@ -4,7 +4,7 @@ const { time, expectRevert, constants } = require("@openzeppelin/test-helpers");
 const Faker = artifacts.require("Faker");
 const TestToken = artifacts.require("TestToken");
 
-contract("Faker", accounts => {
+contract("Faker Auctions", accounts => {
   let instance = null;
   let makerInstance = null;
   let bidTokenInstance = null;

--- a/test/faker-shift.js
+++ b/test/faker-shift.js
@@ -4,7 +4,7 @@ const { time, expectRevert, constants } = require("@openzeppelin/test-helpers");
 const Faker = artifacts.require("Faker");
 const TestToken = artifacts.require("TestToken");
 
-contract("Faker", accounts => {
+contract("Faker Shift", accounts => {
   let instance = null;
   let makerInstance = null;
   let periodLength = null;

--- a/test/faker-time.js
+++ b/test/faker-time.js
@@ -3,7 +3,7 @@ const { time, expectRevert } = require("@openzeppelin/test-helpers");
 
 const Faker = artifacts.require("Faker");
 
-contract("Faker", accounts => {
+contract("Faker Time", accounts => {
   let instance = null;
   let periodLength = null;
   const utils = web3.utils;

--- a/test/faker-voting.js
+++ b/test/faker-voting.js
@@ -1,0 +1,84 @@
+const { time, expectRevert, constants } = require("@openzeppelin/test-helpers");
+// time docs: https://docs.openzeppelin.com/test-helpers/0.5/api#time
+
+const Faker = artifacts.require("Faker");
+const TestToken = artifacts.require("TestToken");
+
+contract("Faker", accounts => {
+  let instance = null;
+  let makerInstance = null;
+  let bidTokenInstance = null;
+  let periodLength = null;
+  const utils = web3.utils;
+  const toWei = utils.toWei;
+  const BN = utils.BN;
+
+  const depositor1 = accounts[1];
+  const depositor2 = accounts[2];
+
+  const bidder1 = accounts[3];
+  const firstBidAmount = toWei("1", "ether");
+  const invalidRefundUseAmount = toWei("1.1", "ether");
+  const bidAdditionAmount = toWei("0.51", "ether");
+  const winningBidAmount = toWei("1.51", "ether");
+
+  const bidder2 = accounts[4];
+  const secondBidAmount = toWei("0.5", "ether");
+  const thirdBidAmount = toWei("1.5", "ether");
+
+  before(async () => {
+    // Deploy Faker
+    instance = await Faker.deployed();
+    periodLength = await instance.periodLength();
+
+    // Get mock Maker token and send tokens to the bidders
+    let makerAddr = await instance.mkrContract();
+    makerInstance = await TestToken.at(makerAddr);
+    await makerInstance.mint(depositor1, toWei("1000", "ether"));
+    await makerInstance.mint(depositor2, toWei("1000", "ether"));
+
+    // Get mock bid token instance
+    let bidTokenAddr = await instance.bidToken();
+    bidTokenInstance = await TestToken.at(bidTokenAddr);
+    await bidTokenInstance.mint(bidder1, toWei("100", "ether"));
+    await bidTokenInstance.mint(bidder2, toWei("100", "ether"));
+
+    // Approve Faker instance to spend Maker
+    await makerInstance.approve(instance.address, constants.MAX_UINT256, {from: depositor1});
+    await makerInstance.approve(instance.address, constants.MAX_UINT256, {from: depositor2});
+    await bidTokenInstance.approve(instance.address, constants.MAX_UINT256, {from: bidder1});
+    await bidTokenInstance.approve(instance.address, constants.MAX_UINT256, {from: bidder2});
+  });
+
+  it("should find the contract instances", async () => {
+    assert(instance.address.startsWith("0x"), "Faker deployment not found");
+    assert(makerInstance.address.startsWith("0x"), "Maker deployment not found");
+  });
+
+  // PERIOD 0
+
+
+
+  // PERIOD 1
+
+  it("should increase time to period 1", async () => {
+    await time.increase(periodLength);
+  });
+
+
+  it("should allow a user to submit a bid in period 1", async () => {
+    await instance.submitBid(toWei("10", "ether"), {from: bidder1});
+
+    let leadingBid = await instance.bids("0");
+    let contractBalance = await bidTokenInstance.balanceOf(instance.address);
+
+    assert.equal(toWei("10", "ether"), contractBalance, "Unexpected Balance");
+    assert.equal(leadingBid.bidder, bidder1, "Unexpected bidder");
+    assert.equal(leadingBid.amount, toWei("10", "ether"), "Unexpected amount");
+  });
+
+  it('should allow depositors to withdraw', async() => {
+
+  })
+
+});

--- a/test/faker-voting.js
+++ b/test/faker-voting.js
@@ -165,4 +165,34 @@ contract("Faker Voting", accounts => {
       "Faker: Not Eligible For Earnings In This Phase"
     );
   });
+
+  it("should allow a user to withdraw earnings for two phases", async () => {
+    await instance.withdrawEarnings(["0", "1"], {from: depositor2});
+
+    let depositor2Balance = await bidTokenInstance.balanceOf(depositor2);
+    let contractBalance = await bidTokenInstance.balanceOf(instance.address);
+
+    assert.equal(depositor2Balance, toWei("9", "ether"), "Unexpected Balance");
+    assert.equal(contractBalance, toWei("6", "ether"), "Unexpected Balance");
+  });
+
+  it("should allow a user to withdraw latest earnings", async () => {
+    await instance.withdrawEarnings(["1"], {from: depositor1});
+
+    let depositor1Balance = await bidTokenInstance.balanceOf(depositor1);
+    let contractBalance = await bidTokenInstance.balanceOf(instance.address);
+
+    assert.equal(depositor1Balance, toWei("9", "ether"), "Unexpected Balance");
+    assert.equal(contractBalance, toWei("2", "ether"), "Unexpected Balance");
+  });
+
+  it("should allow latest user to withdraw earnings", async () => {
+    await instance.withdrawEarnings(["1"], {from: depositor3});
+
+    let depositor3Balance = await bidTokenInstance.balanceOf(depositor3);
+    let contractBalance = await bidTokenInstance.balanceOf(instance.address);
+
+    assert.equal(depositor3Balance, toWei("2", "ether"), "Unexpected Balance");
+    assert.equal(contractBalance, toWei("0", "ether"), "Unexpected Balance");
+  });
 });

--- a/test/faker-voting.js
+++ b/test/faker-voting.js
@@ -98,4 +98,19 @@ contract("Faker Voting", accounts => {
     );
   });
 
+  // PERIOD 2
+
+  it("should increase time to period 2", async () => {
+    await time.increase(periodLength);
+  });
+
+  it("should allow a user to withdraw their earnings from the now-complete auction", async () => {
+    await instance.withdrawEarnings(["0"], {from: depositor1});
+
+    let depositor1Balance = await bidTokenInstance.balanceOf(depositor1);
+    let contractBalance = await bidTokenInstance.balanceOf(instance.address);
+
+    assert.equal(depositor1Balance, toWei("5", "ether"), "Unexpected Balance");
+    assert.equal(contractBalance, toWei("5", "ether"), "Unexpected Balance");
+  });
 });

--- a/test/faker-voting.js
+++ b/test/faker-voting.js
@@ -113,4 +113,11 @@ contract("Faker Voting", accounts => {
     assert.equal(depositor1Balance, toWei("5", "ether"), "Unexpected Balance");
     assert.equal(contractBalance, toWei("5", "ether"), "Unexpected Balance");
   });
+
+  it("should not allow the same user to withdraw their earnings from the same phase twice", async () => {
+    await expectRevert(
+      instance.withdrawEarnings(["0"], {from: depositor1}),
+      "Faker: Earnings For Phase Already Withdrawn"
+    );
+  });
 });

--- a/test/faker-voting.js
+++ b/test/faker-voting.js
@@ -75,7 +75,6 @@ contract("Faker Voting", accounts => {
     await time.increase(periodLength);
   });
 
-
   it("should allow a user to submit a bid in period 1", async () => {
     await instance.submitBid(toWei("10", "ether"), {from: bidder1});
 


### PR DESCRIPTION
As usual, things are more complicated than they seem, but I _think_ this handles all cases, including:

* Preventing double withdrawal of earnings from a given period by a given user
* Ensuring a user cannot claim earnings from a phase in which they did not participate

This code *assumes* that user has withdrawn all their previous earnings before adding or withdrawing Maker, but it does not enforce this, because doing so would require looping over an arbitrary number of phases.

The user could screw himself over by depositing or withdrawing Maker before claiming earnings from past phases. Those earnings would be locked irrevocably. The UI should ensure this is not possible. We might also want to write "safeWithdraw" and "safeDeposit" helper methods which attempt the arbitrary looping— but we can't *rely* on them as the only way to withdraw earnings without making gas assumptionns.