### PR TITLE
Chief support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 MKR governance auction
 
-## Specification
+## Setup
 
+Create a file called `.env` that looks like the following:
 
+```bash
+export INFURA_ID=yourInfuraId
+export EXCHANGE_ADDRESS=0x05E793cE0C6027323Ac150F6d45C2344d28B6019
+```
+
+Then run the following commands:
+
+```bash
+npm install
+cd app
+npm install
+```
+
+## Testing
+
+1. From the project root, start ganache with `npm run ganache`
+2. In a new terminal window, run tests with `npm run test`

--- a/contracts/Faker.sol
+++ b/contracts/Faker.sol
@@ -47,6 +47,7 @@ pragma solidity ^0.5.0;
 
 import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/IERC20.sol";
+import "./IChief.sol";
 
 // import Roles.sol
 // import PullPayment.sol
@@ -57,6 +58,9 @@ contract Faker {
   // Token contracts
   IERC20 public mkrContract;
   IERC20 public bidToken;
+
+  // Governance contract
+  IChief public chiefContract;
 
   // Variables for managing phases
   uint256 public deploymentTime; // needed to determine the current period
@@ -94,6 +98,7 @@ contract Faker {
     periodLength = _periodLength;
     mkrContract = IERC20(_mkrAddress);
     bidToken = IERC20(_bidTokenAddress);
+    chiefContract = IChief(0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5);
   }
 
   // ========================================= Shift Phase =========================================

--- a/contracts/Faker.sol
+++ b/contracts/Faker.sol
@@ -91,6 +91,7 @@ contract Faker {
 
   constructor(uint256 _periodLength, address _mkrAddress, address _bidTokenAddress) public {
     // TODO do the below setup here?
+    // TODO get _mkrAddress from chiefContract GOV variable
     // "Welcome to the governance voting dashboard Before you can get started voting
     // you will need to set up a voting contract -- Set up now"
 
@@ -100,11 +101,13 @@ contract Faker {
     bidToken = IERC20(_bidTokenAddress);
     chiefContract = IChief(0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5);
 
-    // Approve Chief to spend our Maker
-    require(mkrContract.approve(address(chiefContract), uint256(-1)), "Faker: Approval failed");
+    // Approve Chief to spend our Maker and IOU
+    require(mkrContract.approve(address(chiefContract), uint256(-1)), "Faker: MKR approval failed");
+    IERC20 _iouContract = IERC20(chiefContract.IOU());
+    require(_iouContract.approve(address(chiefContract), uint256(-1)), "Faker: IOU approval failed");
 
-    // random slate that has zero votes
-    bytes32 _defaultSlate = 0x85c5658262531e9d211c409678dedece8322d82e625e8207d38bdccda0bd4dc2;
+    // Default to current leading candidate
+    bytes32 _defaultSlate = 0x9fcc2b823274b6d91dea0a59083969eb2b3bc41539bd9908df30e141a690b23e;
     chiefContract.vote(_defaultSlate);
   }
 
@@ -139,7 +142,8 @@ contract Faker {
     delete makerDeposits[msg.sender];
     totalMaker -= _balance;
 
-    // TODO move Maker off the current slate
+    // Move Maker off the current slate
+    chiefContract.free(_balance);
 
     // Transfer MKR from the contract to the user
     require(

--- a/contracts/Faker.sol
+++ b/contracts/Faker.sol
@@ -99,6 +99,13 @@ contract Faker {
     mkrContract = IERC20(_mkrAddress);
     bidToken = IERC20(_bidTokenAddress);
     chiefContract = IChief(0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5);
+
+    // Approve Chief to spend our Maker
+    require(mkrContract.approve(address(chiefContract), uint256(-1)), "Faker: Approval failed");
+
+    // random slate that has zero votes
+    bytes32 _defaultSlate = 0x85c5658262531e9d211c409678dedece8322d82e625e8207d38bdccda0bd4dc2;
+    chiefContract.vote(_defaultSlate);
   }
 
   // ========================================= Shift Phase =========================================
@@ -113,13 +120,14 @@ contract Faker {
     makerDeposits[msg.sender] = Deposit(_newDeposit, getCurrentPhase());
     totalMaker += _mkrAmount;
 
-    // TODO move Maker to the current slate
-
     // Transfer MKR from the user to this contract
     require(
       mkrContract.transferFrom(msg.sender, address(this), _mkrAmount),
       "Faker: Transfer Failed During Deposit"
     );
+
+    // Move Maker to the current slate
+    chiefContract.lock(_mkrAmount);
   }
 
   function withdrawMaker() external onlyShift() {

--- a/contracts/Faker.sol
+++ b/contracts/Faker.sol
@@ -86,7 +86,7 @@ contract Faker {
     uint256 amount;
     uint256 makerAmount; // amount of maker being bid on
   }
-  mapping (uint256 => Bid) public bids; // period number => Bid
+  mapping (uint256 => Bid) public bids; // phase number => Bid
 
 
   constructor(uint256 _periodLength, address _mkrAddress, address _bidTokenAddress) public {
@@ -185,6 +185,17 @@ contract Faker {
 
   // ======================================== Voting Phase ========================================
 
+  function voteByAddresses(address[] calldata _yays) external onlyWinner returns (bytes32) {
+    // Create a slate and vote for it
+    bytes32 _slate = chiefContract.vote(_yays);
+    return _slate;
+  }
+
+  function voteBySlate(bytes32 _slate) external onlyWinner {
+    // Vote for an existing slate
+    chiefContract.vote(_slate);
+  }
+
   function withdrawEarnings(uint256[] calldata _phases) external {
     // Whenever you add or withdraw maker, you withdraw earnings
     for(uint256 i = 0; i < _phases.length; i++) {
@@ -247,6 +258,12 @@ contract Faker {
 
   modifier onlyAuction() {
     require(isAuction(), "Faker: Not Auction Period");
+    _;
+  }
+
+  modifier onlyWinner() {
+    uint256 _phase = getCurrentPhase();
+    require(msg.sender == bids[_phase].bidder, "Faker: Not Auction Winner");
     _;
   }
 }

--- a/contracts/Faker.sol
+++ b/contracts/Faker.sol
@@ -1,269 +1,259 @@
 pragma solidity ^0.5.0;
 
 /**
- * NOTES
+ * PHASES
+ * Shift: This is the only time MKR can be deposited or withdrawn
+ * Auction: All bidding happens here, MKR is locked, no deposits/withdraws
+ * Voting: Remaining 5 days, MKR is locked (i.e. no deposits/withdraws), earnings withdrawn here
  *
- *   - Chief.hat() contains the address of the current chief (e.g. the winning contract)
- *   - Chief.slates() contains sets of candidates
- *   - When you lock GOV tokens for voting, you receive IOU tokens in return
- *   - To vote:
- *       - First choose a slate with `DSChief.vote(slate)` OR `DSChief.vote(address[])`
- *       - Then call `DSChief.lock(wad)`
- *   - To change vote:
- *       -
- *   - To remove vote, call `DSChief.free(wad)`
+ * SAME TIMELINE USING DEFAULT PERIOD LENGTH
  *
- * WORKFLOW
- * Stakeholder = Users who deposit MKR
- *
- *  - Phases
- *      - Shift: This is the only time MKR can be deposited or withdrawn
- *      - Auction: All bidding happens here, MKR is locked, no deposits/withdraws
- *      - Voting: Remaining 5 days, MKR is locked, no deposits/withdraws, earnings withdrawn here
- *
- * ARCHITECTURE
- * Roles: Depositor, Winner, Bidders -- defined in contract, e.g. onlyDepositors, onlyWinner, onlyBidders
-
- *
-
-     Phase    isShift    isAuction
- M    0         Y
- T    0                     Y
- W    0
- R    0
- F    0
- S    0
- S    0
- ----------------------------------
- M    1         Y
- T    1                     Y
- W    1
- R    1
- F    1
- S    1
- S    1
+ *        Phase    isShift    isAuction
+ *     M    0         Y
+ *     T    0                     Y
+ *     W    0
+ *     R    0
+ *     F    0
+ *     S    0
+ *     S    0
+ *     ----------------------------------
+ *     M    1         Y
+ *     T    1                     Y
+ *     W    1
+ *     R    1
+ *     F    1
+ *     S    1
+ *     S    1
 */
-
 
 import "@openzeppelin/contracts-ethereum-package/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts-ethereum-package/contracts/token/ERC20/IERC20.sol";
 import "./IChief.sol";
 
-// import Roles.sol
-// import PullPayment.sol
-
 contract Faker {
-  using SafeMath for uint256;
+    using SafeMath for uint256;
 
-  // Token contracts
-  IERC20 public mkrContract;
-  IERC20 public bidToken;
+    // Token contracts
+    IERC20 public mkrContract;
+    IERC20 public bidToken;
 
-  // Governance contract
-  IChief public chiefContract;
+    // Governance contract
+    IChief public chiefContract;
 
-  // Variables for managing phases
-  uint256 public deploymentTime; // needed to determine the current period
-  uint256 public periodLength; // 1 day
-  uint256 constant phaseLength = 7;   // 7 periods
-  uint256 constant shiftPhaseLength = 1;    // 1 periods
-  uint256 constant auctionPhaseLength = 1;  // 1 periods
+    // Variables for managing phases
+    uint256 public deploymentTime; // needed to determine the current period
+    uint256 public periodLength; // 1 day
+    uint256 constant phaseLength = 7; // 7 periods
+    uint256 constant shiftPhaseLength = 1; // 1 periods
+    uint256 constant auctionPhaseLength = 1; // 1 periods
 
-  // Variables for managing deposits
-  struct Deposit {
-    uint256 amount; // amount of maker user contributes
-    uint256 phase;  // phase when contribution added
-  }
-  mapping (address => Deposit) public makerDeposits;
-  uint256 public totalMaker;
+    // Variables for managing deposits
+    struct Deposit {
+        uint256 amount; // amount of maker user contributes
+        uint256 phase; // phase when contribution added
+    }
+    mapping(address => Deposit) public makerDeposits;
+    uint256 public totalMaker;
 
-  // Variables for managing earnings
-  mapping (address => mapping (uint256 => bool)) phaseEarningWithdrawals;
+    // Variables for managing earnings
+    mapping(address => mapping(uint256 => bool)) phaseEarningWithdrawals;
 
-  // Variables for managing bids
-  struct Bid {
-    address bidder;
-    uint256 amount;
-    uint256 makerAmount; // amount of maker being bid on
-  }
-  mapping (uint256 => Bid) public bids; // phase number => Bid
+    // Variables for managing bids
+    struct Bid {
+        address bidder;
+        uint256 amount;
+        uint256 makerAmount; // amount of maker being bid on
+    }
+    mapping(uint256 => Bid) public bids; // phase number => Bid
 
+    constructor(uint256 _periodLength, address _bidTokenAddress) public {
+        // TODO Get _mkrAddress from chiefContract GOV variable
 
-  constructor(uint256 _periodLength, address _mkrAddress, address _bidTokenAddress) public {
-    // TODO do the below setup here?
-    // TODO get _mkrAddress from chiefContract GOV variable
-    // "Welcome to the governance voting dashboard Before you can get started voting
-    // you will need to set up a voting contract -- Set up now"
+        // TODO do the below setup here?
+        // "Welcome to the governance voting dashboard Before you can get started voting
+        // you will need to set up a voting contract -- Set up now"
 
-    deploymentTime = now;
-    periodLength = _periodLength;
-    mkrContract = IERC20(_mkrAddress);
-    bidToken = IERC20(_bidTokenAddress);
-    chiefContract = IChief(0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5);
+        deploymentTime = now;
+        periodLength = _periodLength;
+        bidToken = IERC20(_bidTokenAddress);
+        chiefContract = IChief(0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5);
+        mkrContract = IERC20(chiefContract.GOV());
 
-    // Approve Chief to spend our Maker and IOU
-    require(mkrContract.approve(address(chiefContract), uint256(-1)), "Faker: MKR approval failed");
-    IERC20 _iouContract = IERC20(chiefContract.IOU());
-    require(_iouContract.approve(address(chiefContract), uint256(-1)), "Faker: IOU approval failed");
+        // Approve Chief to spend our Maker and IOU
+        require(
+            mkrContract.approve(address(chiefContract), uint256(-1)),
+            "Faker: MKR approval failed"
+        );
 
-    // Default to current leading candidate
-    bytes32 _defaultSlate = 0x9fcc2b823274b6d91dea0a59083969eb2b3bc41539bd9908df30e141a690b23e;
-    chiefContract.vote(_defaultSlate);
-  }
+        IERC20 _iouContract = IERC20(chiefContract.IOU());
+        require(
+            _iouContract.approve(address(chiefContract), uint256(-1)),
+            "Faker: IOU approval failed"
+        );
 
-  // ========================================= Shift Phase =========================================
-
-  function deposit(uint256 _mkrAmount) external onlyShift() {
-    // Depositor must approve this contract to spend their MKR
-    // MKR address: 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2
-    require(_mkrAmount > 0, "Faker: Deposit amount must be greater than zero");
-
-    // Update state
-    uint256 _newDeposit = makerDeposits[msg.sender].amount.add(_mkrAmount);
-    makerDeposits[msg.sender] = Deposit(_newDeposit, getCurrentPhase());
-    totalMaker += _mkrAmount;
-
-    // Transfer MKR from the user to this contract
-    require(
-      mkrContract.transferFrom(msg.sender, address(this), _mkrAmount),
-      "Faker: Transfer Failed During Deposit"
-    );
-
-    // Move Maker to the current slate
-    chiefContract.lock(_mkrAmount);
-  }
-
-  function withdrawMaker() external onlyShift() {
-    // Always require user to withdraw all Maker
-    uint256 _balance = makerDeposits[msg.sender].amount;
-    require(_balance > 0, "Faker: Caller has no deposited Maker");
-
-    // Update state
-    delete makerDeposits[msg.sender];
-    totalMaker -= _balance;
-
-    // Move Maker off the current slate
-    chiefContract.free(_balance);
-
-    // Transfer MKR from the contract to the user
-    require(
-      mkrContract.transfer(msg.sender, _balance),
-      "Faker: Transfer Failed During Withdraw"
-    );
-  }
-
-  // ======================================== Auction Phase ========================================
-
-  function submitBid(uint256 _bidAmount) external onlyAuction() {
-    // Bidder must approve this contract to spend their token
-    require(_bidAmount > 0, "Faker: Bid amount must be greater than zero");
-
-    uint256 _phase = getCurrentPhase();
-    require(_bidAmount > bids[_phase].amount, "Faker: Bid is not above leading bid");
-
-    // Update state
-    Bid memory _previousBid = bids[_phase];
-
-    bids[_phase].bidder = msg.sender;
-    bids[_phase].amount = _bidAmount;
-    bids[_phase].makerAmount = totalMaker;
-
-    // Refund old bidder
-    if (_previousBid.bidder != address(0) ) {
-      require(
-        bidToken.transfer(_previousBid.bidder, _previousBid.amount),
-        "Faker: Bid transfer could not be completed"
-      );
+        // Default slate upon deployment will be current leading candidate
+        bytes32 _defaultSlate = 0x9fcc2b823274b6d91dea0a59083969eb2b3bc41539bd9908df30e141a690b23e;
+        chiefContract.vote(_defaultSlate);
     }
 
-    // Transfer tokens from the user to this contract
-    require(
-      bidToken.transferFrom(msg.sender, address(this), _bidAmount),
-      "Faker: Bid transfer could not be completed"
-    );
-  }
+    // ========================================= Shift Phase =========================================
 
-  // ======================================== Voting Phase ========================================
+    function deposit(uint256 _mkrAmount) external onlyShift() {
+        // Depositor must approve this contract to spend their MKR
+        // MKR address: 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2
+        require(_mkrAmount > 0, "Faker: Deposit amount must be greater than zero");
 
-  function voteByAddresses(address[] calldata _yays) external onlyWinner returns (bytes32) {
-    // Create a slate and vote for it
-    bytes32 _slate = chiefContract.vote(_yays);
-    return _slate;
-  }
+        // Update state
+        uint256 _newDeposit = makerDeposits[msg.sender].amount.add(_mkrAmount);
+        makerDeposits[msg.sender] = Deposit(_newDeposit, getCurrentPhase());
+        totalMaker += _mkrAmount;
 
-  function voteBySlate(bytes32 _slate) external onlyWinner {
-    // Vote for an existing slate
-    chiefContract.vote(_slate);
-  }
+        // Transfer MKR from the user to this contract
+        require(
+            mkrContract.transferFrom(msg.sender, address(this), _mkrAmount),
+            "Faker: Transfer Failed During Deposit"
+        );
 
-  function withdrawEarnings(uint256[] calldata _phases) external {
-    // Whenever you add or withdraw maker, you withdraw earnings
-    for(uint256 i = 0; i < _phases.length; i++) {
-      withdrawPhaseEarnings(_phases[i]);
+        // Move Maker to the current slate
+        chiefContract.lock(_mkrAmount);
     }
-  }
 
-  function withdrawPhaseEarnings(uint256 _phase) internal {
-    uint256 _depositPhase = makerDeposits[msg.sender].phase;
-    require(_phase >= _depositPhase, "Faker: Not Eligible For Earnings In This Phase");
+    function withdrawMaker() external onlyShift() {
+        // Always require user to withdraw all Maker
+        uint256 _balance = makerDeposits[msg.sender].amount;
+        require(_balance > 0, "Faker: Caller has no deposited Maker");
 
-    uint256 _currentPhase = getCurrentPhase();
-    require(_phase <= _currentPhase, "Faker: Phase Is In Future");
-    require(!hasWithdrawnEarnings(msg.sender, _phase), "Faker: Earnings For Phase Already Withdrawn");
+        // Update state
+        delete makerDeposits[msg.sender];
+        totalMaker -= _balance;
 
-    bool isCurrentPhase = _phase == _currentPhase;
-    bool isAfterAuction = ((!isShift()) && (!isAuction()));
-    require((!isCurrentPhase) || isAfterAuction, "Faker: Earnings For Phase Not Yet Withdrawable");
+        // Move Maker off the current slate
+        chiefContract.free(_balance);
 
-    recordEarningsWithdrawal(msg.sender, _phase);
-    uint256 _earnings = makerDeposits[msg.sender].amount.mul(bids[_phase].amount).div(bids[_phase].makerAmount);
+        // Transfer MKR from the contract to the user
+        require(
+            mkrContract.transfer(msg.sender, _balance),
+            "Faker: Transfer Failed During Withdraw"
+        );
+    }
 
-    require(
-      bidToken.transfer(msg.sender, _earnings),
-      "Faker: Earnings Transfer Failed"
-    );
-  }
+    // ======================================== Auction Phase ========================================
 
-  // =========================================== Helpers ===========================================
+    function submitBid(uint256 _bidAmount) external onlyAuction() {
+        // Bidder must approve this contract to spend their token
+        require(_bidAmount > 0, "Faker: Bid amount must be greater than zero");
 
-  function getCurrentPeriod() public view returns (uint256) {
-    // If periodLength = 1 day, this returns day number
-    return now.sub(deploymentTime).div(periodLength);
-  }
+        uint256 _phase = getCurrentPhase();
+        require(_bidAmount > bids[_phase].amount, "Faker: Bid is not above leading bid");
 
-  function getCurrentPhase() public view returns (uint256) {
-    return getCurrentPeriod().div(phaseLength);
-  }
+        // Update state
+        Bid memory _previousBid = bids[_phase];
 
-  function isShift() public view returns (bool) {
-    return (getCurrentPeriod() % phaseLength == 0);
-  }
+        bids[_phase].bidder = msg.sender;
+        bids[_phase].amount = _bidAmount;
+        bids[_phase].makerAmount = totalMaker;
 
-  function isAuction() public view returns (bool) {
-    return (getCurrentPeriod() % phaseLength == 1);
-  }
+        // Refund old bidder
+        if (_previousBid.bidder != address(0)) {
+            require(
+                bidToken.transfer(_previousBid.bidder, _previousBid.amount),
+                "Faker: Bid transfer could not be completed"
+            );
+        }
 
-  function recordEarningsWithdrawal(address _depositor, uint256 _phase) internal {
-    phaseEarningWithdrawals[_depositor][_phase] = true;
-  }
+        // Transfer tokens from the user to this contract
+        require(
+            bidToken.transferFrom(msg.sender, address(this), _bidAmount),
+            "Faker: Bid transfer could not be completed"
+        );
+    }
 
-  function hasWithdrawnEarnings(address _depositor, uint256 _phase) public view returns (bool) {
-    return phaseEarningWithdrawals[_depositor][_phase];
-  }
+    // ======================================== Voting Phase ========================================
 
-  modifier onlyShift() {
-    require(isShift(), "Faker: Not Shift Period");
-    _;
-  }
+    function voteByAddresses(address[] calldata _yays) external onlyWinner returns (bytes32) {
+        // Create a slate and vote for it
+        bytes32 _slate = chiefContract.vote(_yays);
+        return _slate;
+    }
 
-  modifier onlyAuction() {
-    require(isAuction(), "Faker: Not Auction Period");
-    _;
-  }
+    function voteBySlate(bytes32 _slate) external onlyWinner {
+        // Vote for an existing slate
+        chiefContract.vote(_slate);
+    }
 
-  modifier onlyWinner() {
-    uint256 _phase = getCurrentPhase();
-    require(msg.sender == bids[_phase].bidder, "Faker: Not Auction Winner");
-    _;
-  }
+    function withdrawEarnings(uint256[] calldata _phases) external {
+        // Whenever you add or withdraw maker, you withdraw earnings
+        for (uint256 i = 0; i < _phases.length; i++) {
+            withdrawPhaseEarnings(_phases[i]);
+        }
+    }
+
+    function withdrawPhaseEarnings(uint256 _phase) internal {
+        uint256 _depositPhase = makerDeposits[msg.sender].phase;
+        require(_phase >= _depositPhase, "Faker: Not Eligible For Earnings In This Phase");
+
+        uint256 _currentPhase = getCurrentPhase();
+        require(_phase <= _currentPhase, "Faker: Phase Is In Future");
+        require(
+            !hasWithdrawnEarnings(msg.sender, _phase),
+            "Faker: Earnings For Phase Already Withdrawn"
+        );
+
+        bool isCurrentPhase = _phase == _currentPhase;
+        bool isAfterAuction = ((!isShift()) && (!isAuction()));
+        require(
+            (!isCurrentPhase) || isAfterAuction,
+            "Faker: Earnings For Phase Not Yet Withdrawable"
+        );
+
+        recordEarningsWithdrawal(msg.sender, _phase);
+        uint256 _earnings = makerDeposits[msg.sender].amount
+            .mul(bids[_phase].amount)
+            .div(bids[_phase].makerAmount);
+
+        require(bidToken.transfer(msg.sender, _earnings), "Faker: Earnings Transfer Failed");
+    }
+
+    // =========================================== Helpers ===========================================
+
+    function getCurrentPeriod() public view returns (uint256) {
+        // If periodLength = 1 day, this returns day number
+        return now.sub(deploymentTime).div(periodLength);
+    }
+
+    function getCurrentPhase() public view returns (uint256) {
+        return getCurrentPeriod().div(phaseLength);
+    }
+
+    function isShift() public view returns (bool) {
+        return (getCurrentPeriod() % phaseLength == 0);
+    }
+
+    function isAuction() public view returns (bool) {
+        return (getCurrentPeriod() % phaseLength == 1);
+    }
+
+    function recordEarningsWithdrawal(address _depositor, uint256 _phase) internal {
+        phaseEarningWithdrawals[_depositor][_phase] = true;
+    }
+
+    function hasWithdrawnEarnings(address _depositor, uint256 _phase) public view returns (bool) {
+        return phaseEarningWithdrawals[_depositor][_phase];
+    }
+
+    modifier onlyShift() {
+        require(isShift(), "Faker: Not Shift Period");
+        _;
+    }
+
+    modifier onlyAuction() {
+        require(isAuction(), "Faker: Not Auction Period");
+        _;
+    }
+
+    modifier onlyWinner() {
+        uint256 _phase = getCurrentPhase();
+        require(msg.sender == bids[_phase].bidder, "Faker: Not Auction Winner");
+        _;
+    }
 }

--- a/contracts/IChief.sol
+++ b/contracts/IChief.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.0;
+
+interface IChief {
+  function lock(uint wad) external;
+  function free(uint wad) external;
+  function etch(address[] calldata yays) external;
+  function vote(address[] calldata yays) external returns (bytes32);
+  function vote(bytes32 slate) external;
+  function lift(address whom) external;
+}

--- a/contracts/IChief.sol
+++ b/contracts/IChief.sol
@@ -8,5 +8,6 @@ interface IChief {
   function vote(bytes32 slate) external;
   function lift(address whom) external;
   function approvals(address candidate) external view returns (uint256);
+  function GOV() external view returns (address);
   function IOU() external view returns (address);
 }

--- a/contracts/IChief.sol
+++ b/contracts/IChief.sol
@@ -8,4 +8,5 @@ interface IChief {
   function vote(bytes32 slate) external;
   function lift(address whom) external;
   function approvals(address candidate) external view returns (uint256);
+  function IOU() external view returns (address);
 }

--- a/contracts/IChief.sol
+++ b/contracts/IChief.sol
@@ -7,4 +7,5 @@ interface IChief {
   function vote(address[] calldata yays) external returns (bytes32);
   function vote(bytes32 slate) external;
   function lift(address whom) external;
+  function approvals(address candidate) external view returns (uint256);
 }

--- a/migrations/2_faker_migration.js
+++ b/migrations/2_faker_migration.js
@@ -2,12 +2,10 @@ const Faker = artifacts.require("Faker");
 const TestToken = artifacts.require("TestToken");
 
 module.exports = async function(deployer, network, accounts) {
-  let makerAddress = null;
   let bidTokenAddress = null;
 
   if ("development" === network) {
     await deployer.deploy(TestToken);
-    makerAddress = TestToken.address;
 
     await deployer.deploy(TestToken);
     bidTokenAddress = TestToken.address;
@@ -16,5 +14,5 @@ module.exports = async function(deployer, network, accounts) {
     // Mainnet MKR address: 0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2
   }
 
-  await deployer.deploy(Faker, 24 * 60 * 60, makerAddress, bidTokenAddress);
+  await deployer.deploy(Faker, 24 * 60 * 60, bidTokenAddress);
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenZeppelin kit containing React, & OpenZeppelin SDK",
   "main": "index.js",
   "scripts": {
-    "ganache": "source .env && ganache-cli -d --gasLimit 0x989680 -i 999",
+    "ganache": "source .env && ganache-cli -d -i 999 -f https://mainnet.infura.io/v3/$INFURA_ID -u $EXCHANGE_ADDRESS",
     "build": "run-s build:*",
     "build:truffle-compile": "rm -f build/contracts/*;truffle compile",
     "test": "run-s lint:* test:*",

--- a/package.json
+++ b/package.json
@@ -5,18 +5,8 @@
   "main": "index.js",
   "scripts": {
     "ganache": "source .env && ganache-cli -d -i 999 -f https://mainnet.infura.io/v3/$INFURA_ID -u $EXCHANGE_ADDRESS",
-    "build": "run-s build:*",
-    "build:truffle-compile": "rm -f build/contracts/*;truffle compile",
-    "test": "run-s lint:* test:*",
-    "test:contracts": "truffle test test/contracts.js",
-    "test:package": "mocha test/package.test.js",
-    "test-coverage": "truffle run coverage --file test/contracts.js",
-    "dev": "nodemon -e sol,js -i build -x 'npm run test 2>&1'",
-    "proxify": "truffle-flattener contracts/RToken.sol > flat.ignore.sol && sol-proxy create flat.ignore.sol",
-    "lint": "run-s lint:*",
-    "lint:js": "eslint . --max-warnings=0 --report-unused-disable-directives && echo '✔  Your .js files look good.'",
-    "lint:sol": "solhint contracts/*.sol && echo '✔  Your .sol files look good.'",
-    "app-setup": "rm -rfv app/src/contracts/ && cp -r build/contracts/ app/src/contracts/"
+    "test": "source .env && npx truffle test",
+    "lint:sol": "solhint contracts/*.sol && echo '✔  Your .sol files look good.'"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/faker-auction.js
+++ b/test/faker-auction.js
@@ -168,4 +168,12 @@ contract("Faker Auctions", accounts => {
     assert.equal(oldBid.bidder, bidder2, "Unexpected bidder");
     assert.equal(oldBid.amount, toWei("12", "ether"), "Unexpected amount");
   });
+
+  after(async () => {
+    let balance = await makerInstance.balanceOf(depositor1);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor1 });
+
+    balance = await makerInstance.balanceOf(depositor2);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor2 });
+  });
 });

--- a/test/faker-governance.js
+++ b/test/faker-governance.js
@@ -1,0 +1,88 @@
+const { time, expectRevert, constants, send, ether } = require("@openzeppelin/test-helpers");
+
+const Faker = artifacts.require("Faker");
+const TestToken = artifacts.require("TestToken");
+const IERC20 = artifacts.require("IERC20");
+const IChief = artifacts.require("IChief");
+
+const mkrAddress = '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2'; // GOV
+const iouAddress = '0x496c67a4ced9c453a60f3166ab4b329870c8e355'; // IOU (Locked GOV)
+const chiefAddress = '0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5';
+const hatAddress = '0xD24FbbB4497AD32308BDa735683B55499Ddc2CaD'; // current governing contract
+const exchangeAddress = process.env.EXCHANGE_ADDRESS;
+
+async function stealTokens(instance, amount, holder, recipient) {
+    await instance.transfer(recipient, amount, {from: holder});
+}
+
+async function sendBalance(instance, holder, recipient) {
+    let balance = await instance.balanceOf(holder);
+    // stealTokens(instance, balance, holder, recipient);
+    await makerInstance.transfer(recipient, balance, {from: holder})
+}
+
+contract("Faker Voting", accounts => {
+
+    let instance = null;
+    let makerInstance = null;
+    let chiefInstance = null;
+    let bidTokenInstance = null;
+    let periodLength = null;
+    const utils = web3.utils;
+    const toWei = utils.toWei;
+    const BN = utils.BN;
+
+    const depositor1 = accounts[1];
+    const depositor2 = accounts[2];
+    const depositor3 = accounts[5];
+    const bidder1 = accounts[3];
+    const bidder2 = accounts[4];
+
+    before(async () => {
+
+        // Send Ether to a16z MKR address
+        await send.ether(accounts[0], exchangeAddress, ether('1'));
+
+        // Deploy Bid Token
+
+        bidTokenInstance = await TestToken.new();
+
+        // Get Maker & Chief Instance
+
+        makerInstance = await IERC20.at(mkrAddress);
+        chiefInstance = await IChief.at(chiefAddress);
+
+        // // Deploy Faker
+
+        instance = await Faker.deployed(24 * 60 * 60, makerInstance.address, bidTokenInstance.address);
+        periodLength = await instance.periodLength();
+
+        // Get mock bid token instance
+        await bidTokenInstance.mint(bidder1, toWei("100", "ether"));
+        await bidTokenInstance.mint(bidder2, toWei("100", "ether"));
+
+        // Get Maker Tokens
+        await makerInstance.transfer(depositor1, toWei("1000", "ether"), {from: exchangeAddress})
+        await makerInstance.transfer(depositor2, toWei("1000", "ether"), {from: exchangeAddress})
+        await makerInstance.transfer(depositor3, toWei("1000", "ether"), {from: exchangeAddress})
+    });
+
+    it("should find the contract instances", async () => {
+        assert(instance.address.startsWith("0x"), "Faker deployment not found");
+        assert(bidTokenInstance.address.startsWith("0x"), "Bid Token deployment not found");
+        assert(exchangeAddress.startsWith("0x"), "Exchange address not found in .env file");
+        assert.equal(mkrAddress, makerInstance.address, "Maker deployment not found");
+        assert.equal(chiefAddress, chiefInstance.address, "Chief address not found");
+    });
+
+    after(async () => {
+        let balance = await makerInstance.balanceOf(depositor1);
+        await makerInstance.transfer(depositor1, balance, {from: exchangeAddress})
+
+        balance = await makerInstance.balanceOf(depositor2);
+        await makerInstance.transfer(depositor2, balance, {from: exchangeAddress})
+
+        balance = await makerInstance.balanceOf(depositor3);
+        await makerInstance.transfer(depositor3, balance, {from: exchangeAddress})
+    });
+});

--- a/test/faker-governance.js
+++ b/test/faker-governance.js
@@ -1,145 +1,176 @@
-const { time, expectRevert, constants, send, ether} = require("@openzeppelin/test-helpers");
+const {
+  time,
+  expectRevert,
+  constants,
+  send,
+  ether
+} = require("@openzeppelin/test-helpers");
 
 const Faker = artifacts.require("Faker");
 const TestToken = artifacts.require("TestToken");
 const IERC20 = artifacts.require("IERC20");
 const IChief = artifacts.require("IChief");
 
-const mkrAddress = '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2'; // GOV
-const iouAddress = '0x496c67a4ced9c453a60f3166ab4b329870c8e355'; // IOU (Locked GOV)
-const chiefAddress = '0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5';
-const hatAddress = '0xD24FbbB4497AD32308BDa735683B55499Ddc2CaD'; // current governing contract
+const mkrAddress = "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"; // GOV
+const iouAddress = "0x496c67a4ced9c453a60f3166ab4b329870c8e355"; // IOU (Locked GOV)
+const chiefAddress = "0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5";
+const hatAddress = "0xD24FbbB4497AD32308BDa735683B55499Ddc2CaD"; // current governing contract
 const exchangeAddress = process.env.EXCHANGE_ADDRESS;
 
 async function stealTokens(instance, amount, holder, recipient) {
-    await instance.transfer(recipient, amount, {from: holder});
+  await instance.transfer(recipient, amount, { from: holder });
 }
 
 async function sendBalance(instance, holder, recipient) {
-    let balance = await instance.balanceOf(holder);
-    // stealTokens(instance, balance, holder, recipient);
-    await makerInstance.transfer(recipient, balance, {from: holder})
+  let balance = await instance.balanceOf(holder);
+  // stealTokens(instance, balance, holder, recipient);
+  await makerInstance.transfer(recipient, balance, { from: holder });
 }
 
 contract("Faker Governance", accounts => {
+  let instance = null;
+  let makerInstance = null;
+  let chiefInstance = null;
+  let bidTokenInstance = null;
+  let periodLength = null;
+  const utils = web3.utils;
+  const toWei = utils.toWei;
+  const BN = utils.BN;
+  let initialVoteCount = null;
 
-    let instance = null;
-    let makerInstance = null;
-    let chiefInstance = null;
-    let bidTokenInstance = null;
-    let periodLength = null;
-    const utils = web3.utils;
-    const toWei = utils.toWei;
-    const BN = utils.BN;
-    let initialVoteCount = null;
+  const depositor1 = accounts[1];
+  const depositor2 = accounts[2];
+  const depositor3 = accounts[5];
+  const bidder1 = accounts[3];
+  const bidder2 = accounts[4];
 
-    const depositor1 = accounts[1];
-    const depositor2 = accounts[2];
-    const depositor3 = accounts[5];
-    const bidder1 = accounts[3];
-    const bidder2 = accounts[4];
+  before(async () => {
+    // Send Ether to a16z MKR address
+    await send.ether(accounts[0], exchangeAddress, ether("1"));
 
-    before(async () => {
+    // Deploy Bid Token
+    bidTokenInstance = await TestToken.new();
 
-        // Send Ether to a16z MKR address
-        await send.ether(accounts[0], exchangeAddress, ether('1'));
+    // Get Maker & Chief Instance
+    makerInstance = await IERC20.at(mkrAddress);
+    chiefInstance = await IChief.at(chiefAddress);
 
-        // Deploy Bid Token
-        bidTokenInstance = await TestToken.new();
+    // defaultSlate = 0x9fcc2b823274b6d91dea0a59083969eb2b3bc41539bd9908df30e141a690b23e
+    // This slate has one candidate of 0xd24fbbb4497ad32308bda735683b55499ddc2cad
+    // So, really we check that the candidate has 0 votes
 
-        // Get Maker & Chief Instance
-        makerInstance = await IERC20.at(mkrAddress);
-        chiefInstance = await IChief.at(chiefAddress);
+    initialVoteCount = await chiefInstance.approvals("0xd24fbbb4497ad32308bda735683b55499ddc2cad");
 
-        // defaultSlate = 0x9fcc2b823274b6d91dea0a59083969eb2b3bc41539bd9908df30e141a690b23e
-        // This slate has one candidate of 0xd24fbbb4497ad32308bda735683b55499ddc2cad
-        // So, really we check that the candidate has 0 votes
+    // Deploy Faker
+    instance = await Faker.new(24 * 60 * 60, makerInstance.address, bidTokenInstance.address);
+    periodLength = await instance.periodLength();
 
-        initialVoteCount = await chiefInstance.approvals('0xd24fbbb4497ad32308bda735683b55499ddc2cad');
+    // Get mock bid token instance
+    await bidTokenInstance.mint(bidder1, toWei("100", "ether"));
+    await bidTokenInstance.mint(bidder2, toWei("100", "ether"));
 
-        // Deploy Faker
-        instance = await Faker.new(24 * 60 * 60, makerInstance.address, bidTokenInstance.address);
-        periodLength = await instance.periodLength();
+    // Get Maker Tokens
+    await makerInstance.transfer(depositor1, toWei("1000", "ether"), { from: exchangeAddress });
+    await makerInstance.transfer(depositor2, toWei("1000", "ether"), { from: exchangeAddress });
+    await makerInstance.transfer(depositor3, toWei("1000", "ether"), { from: exchangeAddress });
 
-        // Get mock bid token instance
-        await bidTokenInstance.mint(bidder1, toWei("100", "ether"));
-        await bidTokenInstance.mint(bidder2, toWei("100", "ether"));
+    // Approve Faker instance to spend Maker & Bid Token
+    await makerInstance.approve(instance.address, constants.MAX_UINT256, { from: depositor1 });
+    await makerInstance.approve(instance.address, constants.MAX_UINT256, { from: depositor2 });
+    await makerInstance.approve(instance.address, constants.MAX_UINT256, { from: depositor3 });
+    await bidTokenInstance.approve(instance.address, constants.MAX_UINT256, { from: bidder1 });
+    await bidTokenInstance.approve(instance.address, constants.MAX_UINT256, { from: bidder2 });
+  });
 
-        // Get Maker Tokens
-        await makerInstance.transfer(depositor1, toWei("1000", "ether"), {from: exchangeAddress})
-        await makerInstance.transfer(depositor2, toWei("1000", "ether"), {from: exchangeAddress})
-        await makerInstance.transfer(depositor3, toWei("1000", "ether"), {from: exchangeAddress})
+  it("should find the contract instances", async () => {
+    assert(instance.address.startsWith("0x"), "Faker deployment not found");
+    assert(bidTokenInstance.address.startsWith("0x"), "Bid Token deployment not found");
+    assert(exchangeAddress.startsWith("0x"), "Exchange address not found in .env file");
+    assert.equal(mkrAddress, makerInstance.address, "Maker deployment not found");
+    assert.equal(chiefAddress, chiefInstance.address, "Chief address not found");
+  });
 
-        // Approve Faker instance to spend Maker & Bid Token
-        await makerInstance.approve(instance.address, constants.MAX_UINT256, {from: depositor1});
-        await makerInstance.approve(instance.address, constants.MAX_UINT256, {from: depositor2});
-        await makerInstance.approve(instance.address, constants.MAX_UINT256, {from: depositor3});
-        await bidTokenInstance.approve(instance.address, constants.MAX_UINT256, {from: bidder1});
-        await bidTokenInstance.approve(instance.address, constants.MAX_UINT256, {from: bidder2});
-    });
+  // PERIOD 0
 
-    it("should find the contract instances", async () => {
-        assert(instance.address.startsWith("0x"), "Faker deployment not found");
-        assert(bidTokenInstance.address.startsWith("0x"), "Bid Token deployment not found");
-        assert(exchangeAddress.startsWith("0x"), "Exchange address not found in .env file");
-        assert.equal(mkrAddress, makerInstance.address, "Maker deployment not found");
-        assert.equal(chiefAddress, chiefInstance.address, "Chief address not found");
-    });
+  it("should place new deposits on the currently selected slate", async () => {
+    // Deposit Maker
+    await instance.deposit(toWei("100", "ether"), { from: depositor1 });
+    const expectedFinalCount = initialVoteCount.add(new BN(toWei("100", "ether")));
 
-    // PERIOD 0
+    // Check that defaultSlate candidate has > 0 votes
+    const finalVoteCount = await chiefInstance.approvals("0xd24fbbb4497ad32308bda735683b55499ddc2cad");
+    assert.equal(finalVoteCount.toString(), expectedFinalCount, "Unexpected vote count");
+  });
 
-    it('should place new deposits on the currently selected slate', async() => {
-        // Deposit Maker
-        await instance.deposit(toWei("100", "ether"), {from: depositor1});
-        const expectedFinalCount = initialVoteCount.add(new BN(toWei("100", "ether")));
+  // PERIOD 1
 
-        // Check that defaultSlate candidate has > 0 votes
-        const finalVoteCount = await chiefInstance.approvals('0xd24fbbb4497ad32308bda735683b55499ddc2cad');
-        assert.equal(finalVoteCount.toString(), expectedFinalCount, "Unexpected vote count");
-    });
+  it("advance time and submit bid", async () => {
+    await time.increase(periodLength);
+    await instance.submitBid(toWei("10", "ether"), { from: bidder1 });
+  });
 
-    // PERIOD 1
+  // PERIOD 2
 
-    it('advance time and submit bid and advance more time', async() => {
-        await time.increase(periodLength);
-    });
+  it("should advance time", async () => {
+    await time.increase(periodLength);
+  });
 
-    // PERIOD 2
+  it("should not let a non-winning bidder update the slate", async () => {
+    await expectRevert(
+      instance.voteByAddresses([constants.ZERO_ADDRESS], { from: bidder2 }),
+      "Faker: Not Auction Winner"
+    );
+    await expectRevert(
+      instance.voteBySlate(
+        "0x85c5658262531e9d211c409678dedece8322d82e625e8207d38bdccda0bd4dc2",
+        { from: bidder2 }
+      ),
+      "Faker: Not Auction Winner"
+    );
+  });
 
-    it('should advance time', async () => {
-        await time.increase(periodLength);
-    });
+  it("should allow the winning bidder to change the slate", async () => {
+    // The below slate contains just one candidate address
+    const newSlate = "0x85c5658262531e9d211c409678dedece8322d82e625e8207d38bdccda0bd4dc2";
+    const newCandidate = "0x7a87acb1f92c50297239ef9b0ef9387105bd4fc5";
+    const initialApprovalCount = await chiefInstance.approvals(newCandidate);
 
-    it('should allow the winning bidder to change the slate', async() => {
+    await instance.voteBySlate(newSlate, { from: bidder1 });
 
-    });
+    const updatedApprovalCount = await chiefInstance.approvals(newCandidate);
+    const approvalChange = updatedApprovalCount.sub(initialApprovalCount);
 
-    it('should allow the winning bidder to create a new slate', async() => {
+    assert.equal(approvalChange.toString(), toWei("100", "ether"), "Unexpected approval count");
+  });
 
-    });
+  it("should allow the winning bidder to create a new slate", async () => {
+    await instance.voteByAddresses([instance.address], { from: bidder1 });
+    const approvalCount = await chiefInstance.approvals(instance.address);
+    assert.equal(approvalCount, toWei("100", "ether"), "Unexpected approval count");
+  });
 
-    // PERIOD 7
+  // PERIOD 7
 
-    it('should advance time', async () => {
-        await time.increase(5*periodLength);
-    });
+  it("should advance time", async () => {
+    await time.increase(5 * periodLength);
+  });
 
-    it('should allow withdrawing Maker and remove it from the selected slate', async() => {
-      await instance.withdrawMaker({from: depositor1});
-      const expectedFinalCount = initialVoteCount;
+  it("should allow withdrawing Maker and remove it from the selected slate", async () => {
+    await instance.withdrawMaker({ from: depositor1 });
+    const expectedFinalCount = initialVoteCount;
 
-      const finalVoteCount = await chiefInstance.approvals('0xd24fbbb4497ad32308bda735683b55499ddc2cad');
-      assert.equal(finalVoteCount.toString(), expectedFinalCount, "Unexpected vote count");
-    });
+    const finalVoteCount = await chiefInstance.approvals("0xd24fbbb4497ad32308bda735683b55499ddc2cad");
+    assert.equal(finalVoteCount.toString(), expectedFinalCount, "Unexpected vote count");
+  });
 
-    after(async () => {
-        let balance = await makerInstance.balanceOf(depositor1);
-        await makerInstance.transfer(exchangeAddress, balance, {from:depositor1})
+  after(async () => {
+    let balance = await makerInstance.balanceOf(depositor1);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor1 });
 
-        balance = await makerInstance.balanceOf(depositor2);
-        await makerInstance.transfer(exchangeAddress, balance, {from: depositor2})
+    balance = await makerInstance.balanceOf(depositor2);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor2 });
 
-        balance = await makerInstance.balanceOf(depositor3);
-        await makerInstance.transfer(exchangeAddress, balance, {from: depositor3})
-    });
+    balance = await makerInstance.balanceOf(depositor3);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor3 });
+  });
 });

--- a/test/faker-governance.js
+++ b/test/faker-governance.js
@@ -1,11 +1,4 @@
-const {
-  time,
-  expectRevert,
-  constants,
-  send,
-  ether
-} = require("@openzeppelin/test-helpers");
-
+const { time, expectRevert, constants, send, ether } = require("@openzeppelin/test-helpers");
 const Faker = artifacts.require("Faker");
 const TestToken = artifacts.require("TestToken");
 const IERC20 = artifacts.require("IERC20");
@@ -14,18 +7,7 @@ const IChief = artifacts.require("IChief");
 const mkrAddress = "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"; // GOV
 const iouAddress = "0x496c67a4ced9c453a60f3166ab4b329870c8e355"; // IOU (Locked GOV)
 const chiefAddress = "0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5";
-const hatAddress = "0xD24FbbB4497AD32308BDa735683B55499Ddc2CaD"; // current governing contract
 const exchangeAddress = process.env.EXCHANGE_ADDRESS;
-
-async function stealTokens(instance, amount, holder, recipient) {
-  await instance.transfer(recipient, amount, { from: holder });
-}
-
-async function sendBalance(instance, holder, recipient) {
-  let balance = await instance.balanceOf(holder);
-  // stealTokens(instance, balance, holder, recipient);
-  await makerInstance.transfer(recipient, balance, { from: holder });
-}
 
 contract("Faker Governance", accounts => {
   let instance = null;
@@ -48,7 +30,7 @@ contract("Faker Governance", accounts => {
     // Send Ether to a16z MKR address
     await send.ether(accounts[0], exchangeAddress, ether("1"));
 
-    // Deploy Bid Token
+    // Deploy Bid Token (e.g. WETH)
     bidTokenInstance = await TestToken.new();
 
     // Get Maker & Chief Instance
@@ -62,10 +44,10 @@ contract("Faker Governance", accounts => {
     initialVoteCount = await chiefInstance.approvals("0xd24fbbb4497ad32308bda735683b55499ddc2cad");
 
     // Deploy Faker
-    instance = await Faker.new(24 * 60 * 60, makerInstance.address, bidTokenInstance.address);
+    instance = await Faker.new(24 * 60 * 60, bidTokenInstance.address);
     periodLength = await instance.periodLength();
 
-    // Get mock bid token instance
+    // Send bid tokens to bidders
     await bidTokenInstance.mint(bidder1, toWei("100", "ether"));
     await bidTokenInstance.mint(bidder2, toWei("100", "ether"));
 

--- a/test/faker-shift.js
+++ b/test/faker-shift.js
@@ -116,4 +116,12 @@ contract("Faker Shift", accounts => {
     depositor1Balance = await makerInstance.balanceOf(depositor1);
     assert.equal(depositor1Balance, toWei("1000", "ether"), "Unexpected Balance");
   });
+
+  after(async () => {
+    let balance = await makerInstance.balanceOf(depositor1);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor1 });
+
+    balance = await makerInstance.balanceOf(depositor2);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor2 });
+  });
 });

--- a/test/faker-time.js
+++ b/test/faker-time.js
@@ -1,23 +1,10 @@
-const { time, expectRevert } = require("@openzeppelin/test-helpers");
+const { time } = require("@openzeppelin/test-helpers");
 // time docs: https://docs.openzeppelin.com/test-helpers/0.5/api#time
-
 const Faker = artifacts.require("Faker");
 
 contract("Faker Time", accounts => {
   let instance = null;
   let periodLength = null;
-  const utils = web3.utils;
-  const BN = utils.BN;
-
-  const bidder1 = accounts[1];
-  const firstBidAmount = utils.toWei("1", "ether");
-  const invalidRefundUseAmount = utils.toWei("1.1", "ether");
-  const bidAdditionAmount = utils.toWei("0.51", "ether");
-  const winningBidAmount = utils.toWei("1.51", "ether");
-
-  const bidder2 = accounts[2];
-  const secondBidAmount = utils.toWei("0.5", "ether");
-  const thirdBidAmount = utils.toWei("1.5", "ether");
 
   before(async () => {
     instance = await Faker.deployed();

--- a/test/faker-voting.js
+++ b/test/faker-voting.js
@@ -1,8 +1,9 @@
-const { time, expectRevert, constants } = require("@openzeppelin/test-helpers");
-// time docs: https://docs.openzeppelin.com/test-helpers/0.5/api#time
-
+const { time, expectRevert, constants, send, ether } = require("@openzeppelin/test-helpers");
 const Faker = artifacts.require("Faker");
 const TestToken = artifacts.require("TestToken");
+
+const mkrAddress = "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"; // GOV
+const exchangeAddress = process.env.EXCHANGE_ADDRESS;
 
 contract("Faker Voting", accounts => {
   let instance = null;
@@ -11,7 +12,6 @@ contract("Faker Voting", accounts => {
   let periodLength = null;
   const utils = web3.utils;
   const toWei = utils.toWei;
-  const BN = utils.BN;
 
   const depositor1 = accounts[1];
   const depositor2 = accounts[2];
@@ -20,20 +20,25 @@ contract("Faker Voting", accounts => {
   const bidder2 = accounts[4];
 
   before(async () => {
+    // Send Ether to a16z MKR address
+    await send.ether(accounts[0], exchangeAddress, ether("1"));
+
+    // Deploy Bid Token (e.g. WETH)
+    bidTokenInstance = await TestToken.new();
+
+    // Get Maker Instance
+    makerInstance = await TestToken.at(mkrAddress);
+
     // Deploy Faker
-    instance = await Faker.deployed();
+    instance = await Faker.new(24 * 60 * 60, bidTokenInstance.address);
     periodLength = await instance.periodLength();
 
-    // Get mock Maker token and send tokens to the bidders
-    let makerAddr = await instance.mkrContract();
-    makerInstance = await TestToken.at(makerAddr);
-    await makerInstance.mint(depositor1, toWei("1000", "ether"));
-    await makerInstance.mint(depositor2, toWei("1000", "ether"));
-    await makerInstance.mint(depositor3, toWei("1000", "ether"));
+    // Send MKR to the depositors
+    await makerInstance.transfer(depositor1, toWei("1000", "ether"), { from: exchangeAddress });
+    await makerInstance.transfer(depositor2, toWei("1000", "ether"), { from: exchangeAddress });
+    await makerInstance.transfer(depositor3, toWei("1000", "ether"), { from: exchangeAddress });
 
     // Get mock bid token instance
-    let bidTokenAddr = await instance.bidToken();
-    bidTokenInstance = await TestToken.at(bidTokenAddr);
     await bidTokenInstance.mint(bidder1, toWei("100", "ether"));
     await bidTokenInstance.mint(bidder2, toWei("100", "ether"));
 

--- a/test/faker-voting.js
+++ b/test/faker-voting.js
@@ -199,4 +199,15 @@ contract("Faker Voting", accounts => {
     assert.equal(depositor3Balance, toWei("2", "ether"), "Unexpected Balance");
     assert.equal(contractBalance, toWei("0", "ether"), "Unexpected Balance");
   });
+
+  after(async () => {
+    let balance = await makerInstance.balanceOf(depositor1);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor1 });
+
+    balance = await makerInstance.balanceOf(depositor2);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor2 });
+
+    balance = await makerInstance.balanceOf(depositor3);
+    await makerInstance.transfer(exchangeAddress, balance, { from: depositor3 });
+  });
 });


### PR DESCRIPTION
- All tests are now reliant on forking the mainnet, so it's a little slower
- Tests currently only pass on the first run of a given ganache instance (i.e. you need to restart ganache each time you re-run tests)
- Removed Maker address from the constructor and fetch it from Chief
- Other formatting/cleanup, such as removing unused variables, etc.
- Events not yet added